### PR TITLE
travis merge pull request to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,15 @@ export EMACS ?= $(shell which emacs)
 export CASK_DIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 
 PKBUILD=2.3
-ifeq ($(TRAVIS_PULL_REQUEST_SLUG),)
-TRAVIS_PULL_REQUEST_SLUG := $(shell git config --global user.name)/$(shell basename `git rev-parse --show-toplevel`)
-endif
 ifeq ($(TRAVIS_PULL_REQUEST_BRANCH),)
 TRAVIS_PULL_REQUEST_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+endif
+ifeq ($(TRAVIS_PULL_REQUEST_SLUG),)
+ifeq ($(TRAVIS_PULL_REQUEST_BRANCH),HEAD)
+TRAVIS_PULL_REQUEST_SLUG := $(TRAVIS_REPO_SLUG)
+else
+TRAVIS_PULL_REQUEST_SLUG := $(shell git config --global user.name)/$(shell basename `git rev-parse --show-toplevel`)
+endif
 endif
 ifeq ($(TRAVIS_PULL_REQUEST_SHA),)
 TRAVIS_PULL_REQUEST_SHA := $(shell git rev-parse origin/$(TRAVIS_PULL_REQUEST_BRANCH))


### PR DESCRIPTION
the github continuous-integration/travis-ci/push will have an unpopulated
TRAVIS_PULL_REQUEST_SLUG and TRAVIS_PULL_REQUEST_BRANCH.

In this case we should set repo to TRAVIS_REPO_SLUG.

M. Engdegard has fixed auto-revert-notify-rm-watch in emacs-27.