### PR TITLE
Callback can take more than five seconds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
     - env: EVM_EMACS=emacs-26.1-travis
     - env: EVM_EMACS=emacs-26.2-travis
     - env: EVM_EMACS=emacs-26.3-travis
+    - env: EVM_EMACS=emacs-27.1-travis
     - env: EVM_EMACS=emacs-git-snapshot-travis
 
   allow_failures:

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,8 @@ $(CASK_DIR): Cask
 compile: cask
 	! ($(CASK) eval \
 	      "(cl-letf (((symbol-function (quote cask-files)) (lambda (&rest _args) (mapcar (function symbol-name) (quote ($(TESTSSRC))))))) \
+	          (require 'deferred) \
+	          (defalias 'deferred:timeout #'ignore) \
 	          (let ((byte-compile-error-on-warn t)) (cask-cli/build)))" 2>&1 | egrep -a "(Warning|Error):") ; (ret=$$? ; rm -f $(ELCTESTS) && exit $$ret)
 	! ($(CASK) eval "(let ((byte-compile-error-on-warn t)) (cask-cli/build))" 2>&1 | egrep -a "(Warning|Error):") ; (ret=$$? ; $(CASK) clean-elc && exit $$ret)
 

--- a/request.el
+++ b/request.el
@@ -1214,7 +1214,8 @@ START-URL is the URL requested."
   (let ((desc auto-revert-notify-watch-descriptor)
         (table (if (boundp 'auto-revert--buffers-by-watch-descriptor)
                    auto-revert--buffers-by-watch-descriptor
-                 auto-revert-notify-watch-descriptor-hash-list)))
+                 (when (boundp 'auto-revert-notify-watch-descriptor-hash-list)
+                   auto-revert-notify-watch-descriptor-hash-list))))
     (when desc
       (let ((buffers (delq (current-buffer) (gethash desc table))))
         (if buffers
@@ -1245,7 +1246,8 @@ START-URL is the URL requested."
           (cl-loop with iter = 0
                    until (or (>= iter maxiter) finished)
                    do (accept-process-output nil interval)
-                   unless (request--process-live-p proc)
+                   if (and (process-sentinel proc)
+                           (not (request--process-live-p proc)))
                      do (cl-incf iter)
                    end
                    finally (when (>= iter maxiter)

--- a/tests/test-request.el
+++ b/tests/test-request.el
@@ -211,6 +211,15 @@ See also:
    (should (equal (assoc-default 'path data) "some-path"))
    (should (equal (assoc-default 'method data) "GET"))))
 
+(request-deftest request-get-sync-callback-persists ()
+  (request-testing-with-response-slots
+      (request (request-testing-url "report/some-path")
+        :sync t :parser 'json-read :success (lambda (&rest _args) (sleep-for 6.5)))
+   (should done-p)
+   (should (equal status-code 200))
+   (should (equal (assoc-default 'path data) "some-path"))
+   (should (equal (assoc-default 'method data) "GET"))))
+
 
 ;;; POST
 


### PR DESCRIPTION
Under :sync t, we waited five seconds for semaphore to flip, but an
arbitrary :success or :complete callback could take longer than that.
This resulted in "semaphore never called".

We use the fact that process sentinel is temporarily set to nil when
running to avoid debiting max iterations while sentinel is taking its
sweet time.